### PR TITLE
Allow Symfony 8 in symfony/cache dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "shipmonk/composer-dependency-analyser": "^1.8",
         "shipmonk/name-collision-detector": "^2.1",
         "shipmonk/phpstan-rules": "^4.1",
-        "symfony/cache": "^6.4 || ^7.0"
+        "symfony/cache": "^6.4 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Updated `symfony/cache` dependency to allow Symfony 8.x

## Changes
- Changed version constraint from `^6.4 || ^7.0` to `^6.4 || ^7.0 || ^8.0`

## Test plan
- Verify CI passes with the updated dependency constraints